### PR TITLE
Make the plugin actually work on Sponge API7 and cleanup a few other things

### DIFF
--- a/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
@@ -143,7 +143,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
                 String cfgStr = new String(ByteStreams.toByteArray(getResource("bukkitConfig.yml")), StandardCharsets.UTF_8);
                 String token = TokenUtil.newToken();
                 cfgStr = cfgStr.replace("%default_token%", token).replace("%ip%", hostAddr);
-                Files.write(cfgStr, config, StandardCharsets.UTF_8);
+                Files.asCharSink(config, StandardCharsets.UTF_8).write(cfgStr);
 
                 /*
                  * Remind hosted server admins to be sure they have the right
@@ -250,19 +250,16 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
                         }
                     })
                     .bind(host, port)
-                    .addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            if (future.isSuccess()) {
-                                serverChannel = future.channel();
-                                getLogger().info("Votifier enabled on socket " + serverChannel.localAddress() + ".");
-                            } else {
-                                SocketAddress socketAddress = future.channel().localAddress();
-                                if (socketAddress == null) {
-                                    socketAddress = new InetSocketAddress(host, port);
-                                }
-                                getLogger().log(Level.SEVERE, "Votifier was not able to bind to " + socketAddress, future.cause());
+                    .addListener((ChannelFutureListener) future -> {
+                        if (future.isSuccess()) {
+                            serverChannel = future.channel();
+                            getLogger().info("Votifier enabled on socket " + serverChannel.localAddress() + ".");
+                        } else {
+                            SocketAddress socketAddress = future.channel().localAddress();
+                            if (socketAddress == null) {
+                                socketAddress = new InetSocketAddress(host, port);
                             }
+                            getLogger().log(Level.SEVERE, "Votifier was not able to bind to " + socketAddress, future.cause());
                         }
                     });
         } else {
@@ -351,12 +348,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
                 getLogger().info("Got a protocol v2 vote record from " + channel.remoteAddress() + " -> " + vote);
             }
         }
-        Bukkit.getScheduler().runTask(this, new Runnable() {
-            @Override
-            public void run() {
-                Bukkit.getPluginManager().callEvent(new VotifierEvent(vote));
-            }
-        });
+        Bukkit.getScheduler().runTask(this, () -> Bukkit.getPluginManager().callEvent(new VotifierEvent(vote)));
     }
 
     @Override
@@ -378,11 +370,6 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
         if (debug) {
             getLogger().info("Got a forwarded vote -> " + v);
         }
-        Bukkit.getScheduler().runTask(this, new Runnable() {
-            @Override
-            public void run() {
-                Bukkit.getPluginManager().callEvent(new VotifierEvent(v));
-            }
-        });
+        Bukkit.getScheduler().runTask(this, () -> Bukkit.getPluginManager().callEvent(new VotifierEvent(v)));
     }
 }

--- a/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
@@ -241,7 +241,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
                     .group(serverGroup)
                     .childHandler(new ChannelInitializer<NioSocketChannel>() {
                         @Override
-                        protected void initChannel(NioSocketChannel channel) throws Exception {
+                        protected void initChannel(NioSocketChannel channel) {
                             channel.attr(VotifierSession.KEY).set(new VotifierSession());
                             channel.attr(VotifierPlugin.KEY).set(NuVotifierBukkit.this);
                             channel.pipeline().addLast("greetingHandler", new VotifierGreetingHandler());
@@ -252,7 +252,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
                     .bind(host, port)
                     .addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             if (future.isSuccess()) {
                                 serverChannel = future.channel();
                                 getLogger().info("Votifier enabled on socket " + serverChannel.localAddress() + ".");
@@ -343,7 +343,7 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
     }
 
     @Override
-    public void onVoteReceived(Channel channel, final Vote vote, VotifierSession.ProtocolVersion protocolVersion) throws Exception {
+    public void onVoteReceived(Channel channel, final Vote vote, VotifierSession.ProtocolVersion protocolVersion) {
         if (debug) {
             if (protocolVersion == VotifierSession.ProtocolVersion.ONE) {
                 getLogger().info("Got a protocol v1 vote record from " + channel.remoteAddress() + " -> " + vote);

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
@@ -108,7 +108,7 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
                 String cfgStr = new String(ByteStreams.toByteArray(getResourceAsStream("bungeeConfig.yml")), StandardCharsets.UTF_8);
                 String token = TokenUtil.newToken();
                 cfgStr = cfgStr.replace("%default_token%", token);
-                Files.write(cfgStr, config, StandardCharsets.UTF_8);
+                Files.asCharSink(config, StandardCharsets.UTF_8).write(cfgStr);
 
                 /*
                  * Remind hosted server admins to be sure they have the right
@@ -207,7 +207,7 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
                         .group(serverGroup)
                         .childHandler(new ChannelInitializer<NioSocketChannel>() {
                             @Override
-                            protected void initChannel(NioSocketChannel channel) throws Exception {
+                            protected void initChannel(NioSocketChannel channel) {
                                 channel.attr(VotifierSession.KEY).set(new VotifierSession());
                                 channel.attr(VotifierPlugin.KEY).set(NuVotifier.this);
                                 channel.pipeline().addLast("greetingHandler", new VotifierGreetingHandler());
@@ -218,7 +218,7 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
                         .bind(host, port)
                         .addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 if (future.isSuccess()) {
                                     serverChannel = future.channel();
                                     getLogger().info("Votifier enabled on socket " + serverChannel.localAddress() + ".");
@@ -335,7 +335,7 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
     }
 
     @Override
-    public void onVoteReceived(Channel channel, final Vote vote, VotifierSession.ProtocolVersion protocolVersion) throws Exception {
+    public void onVoteReceived(Channel channel, final Vote vote, VotifierSession.ProtocolVersion protocolVersion) {
         if (debug) {
             if (protocolVersion == VotifierSession.ProtocolVersion.ONE) {
                 getLogger().info("Got a protocol v1 vote record from " + channel.remoteAddress() + " -> " + vote);

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
@@ -197,41 +197,35 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
         }
 
         // Must set up server asynchronously due to BungeeCord goofiness.
-        FutureTask<?> initTask = new FutureTask<>(Executors.callable(new Runnable() {
-            @Override
-            public void run() {
-                serverGroup = new NioEventLoopGroup(2);
+        FutureTask<?> initTask = new FutureTask<>(Executors.callable(() -> {
+            serverGroup = new NioEventLoopGroup(2);
 
-                new ServerBootstrap()
-                        .channel(NioServerSocketChannel.class)
-                        .group(serverGroup)
-                        .childHandler(new ChannelInitializer<NioSocketChannel>() {
-                            @Override
-                            protected void initChannel(NioSocketChannel channel) {
-                                channel.attr(VotifierSession.KEY).set(new VotifierSession());
-                                channel.attr(VotifierPlugin.KEY).set(NuVotifier.this);
-                                channel.pipeline().addLast("greetingHandler", new VotifierGreetingHandler());
-                                channel.pipeline().addLast("protocolDifferentiator", new VotifierProtocolDifferentiator(false, !disablev1));
-                                channel.pipeline().addLast("voteHandler", new VoteInboundHandler(NuVotifier.this));
+            new ServerBootstrap()
+                    .channel(NioServerSocketChannel.class)
+                    .group(serverGroup)
+                    .childHandler(new ChannelInitializer<NioSocketChannel>() {
+                        @Override
+                        protected void initChannel(NioSocketChannel channel) {
+                            channel.attr(VotifierSession.KEY).set(new VotifierSession());
+                            channel.attr(VotifierPlugin.KEY).set(NuVotifier.this);
+                            channel.pipeline().addLast("greetingHandler", new VotifierGreetingHandler());
+                            channel.pipeline().addLast("protocolDifferentiator", new VotifierProtocolDifferentiator(false, !disablev1));
+                            channel.pipeline().addLast("voteHandler", new VoteInboundHandler(NuVotifier.this));
+                        }
+                    })
+                    .bind(host, port)
+                    .addListener((ChannelFutureListener) future -> {
+                        if (future.isSuccess()) {
+                            serverChannel = future.channel();
+                            getLogger().info("Votifier enabled on socket " + serverChannel.localAddress() + ".");
+                        } else {
+                            SocketAddress socketAddress = future.channel().localAddress();
+                            if (socketAddress == null) {
+                                socketAddress = new InetSocketAddress(host, port);
                             }
-                        })
-                        .bind(host, port)
-                        .addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                if (future.isSuccess()) {
-                                    serverChannel = future.channel();
-                                    getLogger().info("Votifier enabled on socket " + serverChannel.localAddress() + ".");
-                                } else {
-                                    SocketAddress socketAddress = future.channel().localAddress();
-                                    if (socketAddress == null) {
-                                        socketAddress = new InetSocketAddress(host, port);
-                                    }
-                                    getLogger().log(Level.SEVERE, "Votifier was not able to bind to " + socketAddress, future.cause());
-                                }
-                            }
-                        });
-            }
+                            getLogger().log(Level.SEVERE, "Votifier was not able to bind to " + socketAddress, future.cause());
+                        }
+                    });
         }));
         getProxy().getScheduler().runAsync(this, initTask);
         try {
@@ -344,20 +338,10 @@ public class NuVotifier extends Plugin implements VoteHandler, VotifierPlugin {
             }
         }
 
-        getProxy().getScheduler().runAsync(this, new Runnable() {
-            @Override
-            public void run() {
-                getProxy().getPluginManager().callEvent(new VotifierEvent(vote));
-            }
-        });
+        getProxy().getScheduler().runAsync(this, () -> getProxy().getPluginManager().callEvent(new VotifierEvent(vote)));
 
         if (forwardingMethod != null) {
-            getProxy().getScheduler().runAsync(this, new Runnable() {
-                @Override
-                public void run() {
-                    forwardingMethod.forward(vote);
-                }
-            });
+            getProxy().getScheduler().runAsync(this, () -> forwardingMethod.forward(vote));
         }
     }
 

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/cache/FileVoteCache.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/cache/FileVoteCache.java
@@ -31,14 +31,11 @@ public class FileVoteCache extends MemoryVoteCache {
 
         load();
 
-        saveTask = ProxyServer.getInstance().getScheduler().schedule(plugin, new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    save();
-                } catch (IOException e) {
-                    l.log(Level.SEVERE, "Unable to save cached votes, votes will be lost if you restart.", e);
-                }
+        saveTask = ProxyServer.getInstance().getScheduler().schedule(plugin, () -> {
+            try {
+                save();
+            } catch (IOException e) {
+                l.log(Level.SEVERE, "Unable to save cached votes, votes will be lost if you restart.", e);
             }
         }, 3, 3, TimeUnit.MINUTES);
     }

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/ProxyForwardingVoteSource.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/ProxyForwardingVoteSource.java
@@ -80,12 +80,9 @@ public class ProxyForwardingVoteSource implements ForwardingVoteSource {
                     }
                 })
                 .connect(server.address)
-                .addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            handleFailure(server, v, future.cause(), tries);
-                        }
+                .addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        handleFailure(server, v, future.cause(), tries);
                     }
                 });
     }
@@ -112,12 +109,7 @@ public class ProxyForwardingVoteSource implements ForwardingVoteSource {
         }
 
         if (willRetry) {
-            plugin.getProxy().getScheduler().schedule(plugin, new Runnable() {
-                @Override
-                public void run() {
-                    forwardVote(server, v, tries + 1);
-                }
-            }, nextDelay, TimeUnit.SECONDS);
+            plugin.getProxy().getScheduler().schedule(plugin, () -> forwardVote(server, v, tries + 1), nextDelay, TimeUnit.SECONDS);
         }
     }
 

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/ProxyForwardingVoteSource.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/ProxyForwardingVoteSource.java
@@ -59,7 +59,7 @@ public class ProxyForwardingVoteSource implements ForwardingVoteSource {
                 .group(eventLoopGroup)
                 .handler(new ChannelInitializer<NioSocketChannel>() {
                     @Override
-                    protected void initChannel(NioSocketChannel channel) throws Exception {
+                    protected void initChannel(NioSocketChannel channel) {
                         channel.pipeline().addLast(new DelimiterBasedFrameDecoder(256, true, Delimiters.lineDelimiter()));
                         channel.pipeline().addLast(new ReadTimeoutHandler(8, TimeUnit.SECONDS));
                         channel.pipeline().addLast(STRING_DECODER);
@@ -82,7 +82,7 @@ public class ProxyForwardingVoteSource implements ForwardingVoteSource {
                 .connect(server.address)
                 .addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             handleFailure(server, v, future.cause(), tries);
                         }

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/client/VotifierProtocol2HandshakeHandler.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/client/VotifierProtocol2HandshakeHandler.java
@@ -18,7 +18,7 @@ public class VotifierProtocol2HandshakeHandler extends SimpleChannelInboundHandl
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, String s) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, String s) {
         String[] handshakeContents = s.split(" ");
         if (handshakeContents.length != 3) {
             throw new CorruptedFrameException("Handshake is not valid.");
@@ -35,7 +35,7 @@ public class VotifierProtocol2HandshakeHandler extends SimpleChannelInboundHandl
 
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         responseHandler.onFailure(cause);
         ctx.close();
     }

--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/client/VotifierProtocol2ResponseHandler.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/forwarding/proxy/client/VotifierProtocol2ResponseHandler.java
@@ -13,7 +13,7 @@ public class VotifierProtocol2ResponseHandler extends SimpleChannelInboundHandle
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, String msg) {
         JsonObject object = GsonInst.gson.fromJson(msg, JsonObject.class);
         String status = object.get("status").getAsString();
         if (status.equals("ok")) {
@@ -26,7 +26,7 @@ public class VotifierProtocol2ResponseHandler extends SimpleChannelInboundHandle
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         responseHandler.onFailure(cause);
         ctx.close();
     }

--- a/common/src/main/java/com/vexsoftware/votifier/net/protocol/VoteInboundHandler.java
+++ b/common/src/main/java/com/vexsoftware/votifier/net/protocol/VoteInboundHandler.java
@@ -33,7 +33,7 @@ public class VoteInboundHandler extends SimpleChannelInboundHandler<Vote> {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         VotifierSession session = ctx.channel().attr(VotifierSession.KEY).get();
 
         handler.onError(ctx.channel(), session.hasCompletedVote(), cause);

--- a/common/src/main/java/com/vexsoftware/votifier/net/protocol/VotifierGreetingHandler.java
+++ b/common/src/main/java/com/vexsoftware/votifier/net/protocol/VotifierGreetingHandler.java
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class VotifierGreetingHandler extends ChannelInboundHandlerAdapter {
     @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    public void channelActive(ChannelHandlerContext ctx) {
         VotifierSession session = ctx.channel().attr(VotifierSession.KEY).get();
         VotifierPlugin plugin = ctx.channel().attr(VotifierPlugin.KEY).get();
 

--- a/common/src/main/java/com/vexsoftware/votifier/net/protocol/VotifierProtocol1Decoder.java
+++ b/common/src/main/java/com/vexsoftware/votifier/net/protocol/VotifierProtocol1Decoder.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 public class VotifierProtocol1Decoder extends ByteToMessageDecoder {
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> list) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> list) {
         if (buf.readableBytes() < 256) {
             return;
         }

--- a/common/src/main/java/com/vexsoftware/votifier/net/protocol/VotifierProtocolDifferentiator.java
+++ b/common/src/main/java/com/vexsoftware/votifier/net/protocol/VotifierProtocolDifferentiator.java
@@ -26,7 +26,7 @@ public class VotifierProtocolDifferentiator extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> list) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> list) {
         // Determine the number of bytes that are available.
         int readable = buf.readableBytes();
 

--- a/common/src/main/java/com/vexsoftware/votifier/util/standalone/StandaloneVotifierPlugin.java
+++ b/common/src/main/java/com/vexsoftware/votifier/util/standalone/StandaloneVotifierPlugin.java
@@ -36,7 +36,7 @@ public class StandaloneVotifierPlugin implements VotifierPlugin, VoteHandler {
         this.v1Key = v1Key;
     }
 
-    public Throwable start() throws Throwable {
+    public Throwable start() {
         group = new NioEventLoopGroup(2);
 
         ChannelFuture future = new ServerBootstrap()
@@ -44,7 +44,7 @@ public class StandaloneVotifierPlugin implements VotifierPlugin, VoteHandler {
                 .group(group)
                 .childHandler(new ChannelInitializer<NioSocketChannel>() {
                     @Override
-                    protected void initChannel(NioSocketChannel channel) throws Exception {
+                    protected void initChannel(NioSocketChannel channel) {
                         channel.attr(VotifierSession.KEY).set(new VotifierSession());
                         channel.attr(VotifierPlugin.KEY).set(StandaloneVotifierPlugin.this);
                         channel.pipeline().addLast("greetingHandler", new VotifierGreetingHandler());

--- a/common/src/test/java/com/vexsoftware/votifier/net/protocol/VotifierProtocol2DecoderTest.java
+++ b/common/src/test/java/com/vexsoftware/votifier/net/protocol/VotifierProtocol2DecoderTest.java
@@ -62,7 +62,7 @@ public class VotifierProtocol2DecoderTest {
     }
 
     @Test(expected = DecoderException.class)
-    public void testFailureDecodeBadPacket() throws Exception {
+    public void testFailureDecodeBadPacket() {
         // Create a well-formed request
         EmbeddedChannel channel = createChannel();
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Feb 24 13:39:00 EST 2018
+#Thu May 31 03:56:27 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip

--- a/sponge/build.gradle
+++ b/sponge/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compileOnly group: "org.spongepowered", name: "spongeapi", version: "7.0.0-SNAPSHOT"
+    compileOnly group: "org.spongepowered", name: "spongeapi", version: "7.1.0-SNAPSHOT"
     compile project(":nuvotifier-common")
 }

--- a/sponge/build.gradle
+++ b/sponge/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compileOnly group: "org.spongepowered", name: "spongeapi", version: "7.0.0"
+    compileOnly group: "org.spongepowered", name: "spongeapi", version: "7.0.0-SNAPSHOT"
     compile project(":nuvotifier-common")
 }

--- a/sponge/build.gradle
+++ b/sponge/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compileOnly group: "org.spongepowered", name: "spongeapi", version: "7.1.0-SNAPSHOT"
+    compileOnly group: "org.spongepowered", name: "spongeapi", version: "7.0.0"
     compile project(":nuvotifier-common")
 }

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
@@ -1,8 +1,5 @@
 package com.vexsoftware.votifier.sponge;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import com.vexsoftware.votifier.VoteHandler;
 import com.vexsoftware.votifier.model.Vote;
@@ -13,61 +10,47 @@ import com.vexsoftware.votifier.net.protocol.VotifierProtocolDifferentiator;
 import com.vexsoftware.votifier.net.protocol.v1crypto.RSAIO;
 import com.vexsoftware.votifier.net.protocol.v1crypto.RSAKeygen;
 import com.vexsoftware.votifier.sponge.config.ConfigLoader;
-import com.vexsoftware.votifier.sponge.config.SpongeConfig;
 import com.vexsoftware.votifier.sponge.event.VotifierEvent;
 import com.vexsoftware.votifier.sponge.forwarding.ForwardedVoteListener;
 import com.vexsoftware.votifier.sponge.forwarding.ForwardingVoteSink;
 import com.vexsoftware.votifier.sponge.forwarding.SpongePluginMessagingForwardingSink;
 import com.vexsoftware.votifier.util.KeyCreator;
-import com.vexsoftware.votifier.util.TokenUtil;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import ninja.leaping.configurate.ConfigurationNode;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
-import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
 import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.config.ConfigDir;
 import org.spongepowered.api.event.Listener;
-import org.spongepowered.api.event.game.state.GamePostInitializationEvent;
-import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.game.state.GameStoppingServerEvent;
 import org.spongepowered.api.plugin.Plugin;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.Key;
 import java.security.KeyPair;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 @Plugin(id = "nuvotifier", name = "NuVotifier", version = "2.3.7", authors = "ParallelBlock LLC",
         description = "Safe, smart, and secure Votifier server plugin")
 public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.VotifierPlugin, ForwardedVoteListener {
 
     @Inject
-    private Logger logger;
+    public Logger logger;
 
     @Inject
     @ConfigDir(sharedRoot = false)
-    private File configDir;
+    public File configDir;
 
     @Listener
-    public void onServerStart(GamePreInitializationEvent event) {
+    public void onServerStart(GameStartedServerEvent event) {
         // Handle configuration.
         ConfigLoader cfgLoader = new ConfigLoader(this);
 
@@ -123,7 +106,7 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
                     .group(serverGroup)
                     .childHandler(new ChannelInitializer<NioSocketChannel>() {
                         @Override
-                        protected void initChannel(NioSocketChannel channel) throws Exception {
+                        protected void initChannel(NioSocketChannel channel) {
                             channel.attr(VotifierSession.KEY).set(new VotifierSession());
                             channel.attr(com.vexsoftware.votifier.VotifierPlugin.KEY).set(VotifierPlugin.this);
                             channel.pipeline().addLast("greetingHandler", new VotifierGreetingHandler());
@@ -251,7 +234,7 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
     }
 
     @Override
-    public void onVoteReceived(Channel channel, final Vote vote, VotifierSession.ProtocolVersion protocolVersion) throws Exception {
+    public void onVoteReceived(Channel channel, final Vote vote, VotifierSession.ProtocolVersion protocolVersion) {
         if (debug) {
             if (protocolVersion == VotifierSession.ProtocolVersion.ONE) {
                 logger.info("Got a protocol v1 vote record from " + channel.remoteAddress() + " -> " + vote);

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
@@ -54,21 +54,16 @@ import java.util.Optional;
 @Plugin(id = "nuvotifier", name = "NuVotifier", version = "2.3.7", authors = "ParallelBlock LLC",
         description = "Safe, smart, and secure Votifier server plugin")
 public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.VotifierPlugin, ForwardedVoteListener {
+
+    @Inject
     private Logger logger;
+
     @Inject
     @ConfigDir(sharedRoot = false)
     private Path baseDirectory;
 
-    @Inject
-    public VotifierPlugin(Logger logger) {
-        this.logger = logger;
-    }
-
     @Listener
     public void onServerStart(GameStartedServerEvent event) {
-        // Set the plugin version.
-        version = this.getClass().getAnnotation(Plugin.class).version();
-
         // Handle configuration.
         Path config = baseDirectory.resolve("config.yml");
         File rsaDirectory = baseDirectory.resolve("rsa").toFile();

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
@@ -243,12 +243,9 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
             }
         }
         Sponge.getScheduler().createTaskBuilder()
-                .execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        VotifierEvent event = new VotifierEvent(vote, Sponge.getCauseStackManager().getCurrentCause());
-                        Sponge.getEventManager().post(event);
-                    }
+                .execute(() -> {
+                    VotifierEvent event = new VotifierEvent(vote, Sponge.getCauseStackManager().getCurrentCause());
+                    Sponge.getEventManager().post(event);
                 })
                 .submit(this);
     }
@@ -273,12 +270,9 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
             logger.info("Got a forwarded vote -> " + v);
         }
         Sponge.getScheduler().createTaskBuilder()
-                .execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        VotifierEvent event = new VotifierEvent(v, Sponge.getCauseStackManager().getCurrentCause());
-                        Sponge.getEventManager().post(event);
-                    }
+                .execute(() -> {
+                    VotifierEvent event = new VotifierEvent(v, Sponge.getCauseStackManager().getCurrentCause());
+                    Sponge.getEventManager().post(event);
                 })
                 .submit(this);
     }

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/VotifierPlugin.java
@@ -51,11 +51,8 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
 
     @Listener
     public void onServerStart(GameStartedServerEvent event) {
-        // Handle configuration.
-        ConfigLoader cfgLoader = new ConfigLoader(this);
-
         // Load configuration.
-        cfgLoader.loadConfig();
+        ConfigLoader.loadConfig(this);
 
         /*
          * Create RSA directory and keys if it does not exist; otherwise, read
@@ -76,22 +73,22 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
             return;
         }
 
-        debug = cfgLoader.getSpongeConfig().debug;
+        debug = ConfigLoader.getSpongeConfig().debug;
 
         // Load Votifier tokens.
-        cfgLoader.getSpongeConfig().tokens.forEach((s, s2) -> {
+        ConfigLoader.getSpongeConfig().tokens.forEach((s, s2) -> {
             tokens.put(s, KeyCreator.createKeyFrom(s2));
             logger.info("Loaded token for website: " + s);
         });
 
         // Initialize the receiver.
-        final String host = cfgLoader.getSpongeConfig().host;
-        final int port = cfgLoader.getSpongeConfig().port;
+        final String host = ConfigLoader.getSpongeConfig().host;
+        final int port = ConfigLoader.getSpongeConfig().port;
         if (debug)
             logger.info("DEBUG mode enabled!");
 
         if (port >= 0) {
-            final boolean disablev1 = cfgLoader.getSpongeConfig().disableV1Protocol;
+            final boolean disablev1 = ConfigLoader.getSpongeConfig().disableV1Protocol;
             if (disablev1) {
                 logger.info("------------------------------------------------------------------------------");
                 logger.info("Votifier protocol v1 parsing has been disabled. Most voting websites do not");
@@ -135,12 +132,12 @@ public class VotifierPlugin implements VoteHandler, com.vexsoftware.votifier.Vot
             getLogger().info("------------------------------------------------------------------------------");
         }
 
-        if (cfgLoader.getSpongeConfig().forwarding != null) {
-            String method = cfgLoader.getSpongeConfig().forwarding.method.toLowerCase(); //Default to lower case for case-insensitive searches
+        if (ConfigLoader.getSpongeConfig().forwarding != null) {
+            String method = ConfigLoader.getSpongeConfig().forwarding.method.toLowerCase(); //Default to lower case for case-insensitive searches
             if ("none".equals(method)) {
                 getLogger().info("Method none selected for vote forwarding: Votes will not be received from a forwarder.");
             } else if ("pluginmessaging".equals(method)) {
-                String channel = cfgLoader.getSpongeConfig().forwarding.pluginMessaging.channel;
+                String channel = ConfigLoader.getSpongeConfig().forwarding.pluginMessaging.channel;
                 try {
                     forwardingMethod = new SpongePluginMessagingForwardingSink(this, channel, this);
                     getLogger().info("Receiving votes over PluginMessaging channel '" + channel + "'.");

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/ConfigLoader.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/ConfigLoader.java
@@ -2,10 +2,11 @@ package com.vexsoftware.votifier.sponge.config;
 
 import com.google.common.reflect.TypeToken;
 import com.vexsoftware.votifier.sponge.VotifierPlugin;
+import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
-import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
+import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
 
 import java.io.File;
 
@@ -23,12 +24,12 @@ public class ConfigLoader {
 
     public boolean loadConfig() {
         try {
-            File file = new File(plugin.getConfigDir(), "config.conf");
+            File file = new File(plugin.getConfigDir(), "config.yml");
             if (!file.exists()) {
                 file.createNewFile();
             }
-            ConfigurationLoader<CommentedConfigurationNode> loader = HoconConfigurationLoader.builder().setFile(file).build();
-            CommentedConfigurationNode config = loader.load(ConfigurationOptions.defaults().setShouldCopyDefaults(true));
+            ConfigurationLoader loader = YAMLConfigurationLoader.builder().setFile(file).build();
+            ConfigurationNode config = loader.load(ConfigurationOptions.defaults().setShouldCopyDefaults(true));
             spongeConfig = config.getValue(TypeToken.of(SpongeConfig.class), new SpongeConfig());
             loader.save(config);
             return true;

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/ConfigLoader.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/ConfigLoader.java
@@ -1,0 +1,44 @@
+package com.vexsoftware.votifier.sponge.config;
+
+import com.google.common.reflect.TypeToken;
+import com.vexsoftware.votifier.sponge.VotifierPlugin;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+
+import java.io.File;
+
+public class ConfigLoader {
+
+    private final VotifierPlugin plugin;
+    private SpongeConfig spongeConfig;
+
+    public ConfigLoader(VotifierPlugin pl) {
+        this.plugin = pl;
+        if (!plugin.getConfigDir().exists()) {
+            plugin.getConfigDir().mkdirs();
+        }
+    }
+
+    public boolean loadConfig() {
+        try {
+            File file = new File(plugin.getConfigDir(), "config.conf");
+            if (!file.exists()) {
+                file.createNewFile();
+            }
+            ConfigurationLoader<CommentedConfigurationNode> loader = HoconConfigurationLoader.builder().setFile(file).build();
+            CommentedConfigurationNode config = loader.load(ConfigurationOptions.defaults().setShouldCopyDefaults(true));
+            spongeConfig = config.getValue(TypeToken.of(SpongeConfig.class), new SpongeConfig());
+            loader.save(config);
+            return true;
+        } catch (Exception e) {
+            plugin.getLogger().error("Could not load config.", e);
+            return false;
+        }
+    }
+
+    public SpongeConfig getSpongeConfig() {
+        return spongeConfig;
+    }
+}

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/ConfigLoader.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/ConfigLoader.java
@@ -4,7 +4,6 @@ import com.google.common.reflect.TypeToken;
 import com.vexsoftware.votifier.sponge.VotifierPlugin;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
-import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
 
@@ -12,17 +11,14 @@ import java.io.File;
 
 public class ConfigLoader {
 
-    private final VotifierPlugin plugin;
-    private SpongeConfig spongeConfig;
+    private static VotifierPlugin plugin;
+    private static SpongeConfig spongeConfig;
 
-    public ConfigLoader(VotifierPlugin pl) {
-        this.plugin = pl;
+    public static void loadConfig(VotifierPlugin pl) {
+        plugin = pl;
         if (!plugin.getConfigDir().exists()) {
             plugin.getConfigDir().mkdirs();
         }
-    }
-
-    public boolean loadConfig() {
         try {
             File file = new File(plugin.getConfigDir(), "config.yml");
             if (!file.exists()) {
@@ -32,14 +28,12 @@ public class ConfigLoader {
             ConfigurationNode config = loader.load(ConfigurationOptions.defaults().setShouldCopyDefaults(true));
             spongeConfig = config.getValue(TypeToken.of(SpongeConfig.class), new SpongeConfig());
             loader.save(config);
-            return true;
         } catch (Exception e) {
             plugin.getLogger().error("Could not load config.", e);
-            return false;
         }
     }
 
-    public SpongeConfig getSpongeConfig() {
+    public static SpongeConfig getSpongeConfig() {
         return spongeConfig;
     }
 }

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/SpongeConfig.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/SpongeConfig.java
@@ -35,7 +35,7 @@ public class SpongeConfig {
     public Forwarding forwarding = new Forwarding();
 
     @ConfigSerializable
-    public class Forwarding {
+    public static class Forwarding {
 
         @Setting(comment = "Sets whether to set up a remote method for fowarding. Supported methods:\n" +
                 "- none - Does not set up a forwarding method.\n" +
@@ -46,7 +46,7 @@ public class SpongeConfig {
         public PluginMessaging pluginMessaging = new PluginMessaging();
 
         @ConfigSerializable
-        public class PluginMessaging {
+        public static class PluginMessaging {
 
             @Setting
             public String channel = "NuVotifier";

--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/SpongeConfig.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/SpongeConfig.java
@@ -1,0 +1,55 @@
+package com.vexsoftware.votifier.sponge.config;
+
+import com.vexsoftware.votifier.util.TokenUtil;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import org.spongepowered.api.Sponge;
+
+import java.util.Collections;
+import java.util.Map;
+
+@ConfigSerializable
+public class SpongeConfig {
+
+    @Setting(comment = "The IP to listen to. Use 0.0.0.0 if you wish to listen to all interfaces on your server. (All IP addresses)\n" +
+            "This defaults to the IP you have configured your server to listen on, or 0.0.0.0 if you have not configured this.")
+    public String host = Sponge.getServer().getBoundAddress().isPresent() ? Sponge.getServer().getBoundAddress().get().getAddress().getHostAddress() : "0.0.0.0";
+
+    @Setting(comment = "Port to listen for new votes on")
+    public int port = 8192;
+
+    @Setting(comment = "Whether or not to print debug messages. In a production system, this should be set to false.\n" +
+            "This is useful when initially setting up NuVotifier to ensure votes are being delivered.")
+    public boolean debug = false;
+
+    @Setting( value = "disable-v1-protocol", comment = "Setting this option to true will disable handling of Protocol v1 packets. While the old protocol is not secure, this\n" +
+            "option is currently not recommended as most voting sites only support the old protocol at present. However, if you are\n" +
+            "using NuVotifier's proxy forwarding mechanism, enabling this option will increase your server's security.")
+    public boolean disableV1Protocol = false;
+
+    @Setting(comment = "All tokens, labeled by the serviceName of each server list.\n" +
+            "Default token for all server lists, if another isn't supplied.")
+    public Map<String, String> tokens = Collections.singletonMap("default", TokenUtil.newToken());
+
+    @Setting(comment = "Configuration section for all vote forwarding to NuVotifier")
+    public Forwarding forwarding = new Forwarding();
+
+    @ConfigSerializable
+    public class Forwarding {
+
+        @Setting(comment = "Sets whether to set up a remote method for fowarding. Supported methods:\n" +
+                "- none - Does not set up a forwarding method.\n" +
+                "- pluginMessaging - Sets up plugin messaging")
+        public String method = "none";
+
+        @Setting
+        public PluginMessaging pluginMessaging = new PluginMessaging();
+
+        @ConfigSerializable
+        public class PluginMessaging {
+
+            @Setting
+            public String channel = "NuVotifier";
+        }
+    }
+}

--- a/universal/build.gradle
+++ b/universal/build.gradle
@@ -20,7 +20,8 @@ shadowJar {
     classifier = null
     relocate "io.netty", "com.vexsoftware.votifier.netty"
     relocate "org.json", "com.vexsoftware.votifier.json"
-    relocate "com.google", "com.vexsoftware.votifier.google"
+    relocate "com.google.code", "com.vexsoftware.votifier.google"
+    relocate "com.google.guava", "com.vexsoftware.votifier.google"
     relocate "org.apache.commons.io", "com.vexsoftware.votifier.commons.io"
 }
 


### PR DESCRIPTION
This commit https://github.com/parallelblock/NuVotifier/commit/2673fc2d4dfdc817fee6ffae8d3239802c233eeb caused sponge servers to be completely unable to use the plugin. The main problem being `com.google.inject` was being relocated so Sponge was unable to provide the Logger or the configDir to the plugin. To resolve that, I only the com.google libraries you needed for the Bungee part of the plugin. 
I also redid the way the config was loaded on Sponge servers. I was considering replacing the YAML format with HOCON, to make it more friendly for Sponge admins, but I didn't have time to write a converter to convert the old YAML configs to HOCON, so any new configs currently generated on sponge won't have any comments. 