### PR TITLE
Fixed reference to capitialized channel name

### DIFF
--- a/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/SpongeConfig.java
+++ b/sponge/src/main/java/com/vexsoftware/votifier/sponge/config/SpongeConfig.java
@@ -49,7 +49,7 @@ public class SpongeConfig {
         public static class PluginMessaging {
 
             @Setting
-            public String channel = "NuVotifier:votes";
+            public String channel = "nuvotifier:votes";
         }
     }
 }


### PR DESCRIPTION
You might want to issue 2.4.1 again because you missed a spot in the Sponge plugin.