### PR TITLE
Port to the latest Velocity API

### DIFF
--- a/velocity/src/main/java/com/vexsoftware/votifier/velocity/PluginMessagingForwardingSource.java
+++ b/velocity/src/main/java/com/vexsoftware/votifier/velocity/PluginMessagingForwardingSource.java
@@ -1,8 +1,8 @@
 package com.vexsoftware.votifier.velocity;
 
 import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
-import com.velocitypowered.api.proxy.messages.MessageHandler;
 import com.vexsoftware.votifier.support.forwarding.AbstractPluginMessagingForwardingSource;
 import com.vexsoftware.votifier.support.forwarding.cache.VoteCache;
 
@@ -16,11 +16,17 @@ public class PluginMessagingForwardingSource extends AbstractPluginMessagingForw
         super(channel, ignoredServers, plugin, cache, dumpRate);
         this.plugin = plugin;
         plugin.getServer().getEventManager().register(plugin, this);
-        plugin.getServer().getChannelRegistrar().register((source, side, identifier, data) -> MessageHandler.ForwardStatus.HANDLED, VelocityUtil.getId(channel));
     }
 
     @Subscribe
     public void onServerConnected(final ServerConnectedEvent e) { //Attempt to resend any votes that were previously cached.
         onServerConnect(new VelocityBackendServer(plugin.getServer(), e.getServer()));
+    }
+
+    @Subscribe
+    public void onPluginMessage(PluginMessageEvent e) {
+        if (e.getIdentifier().equals(VelocityUtil.getId(channel))) {
+            e.setResult(PluginMessageEvent.ForwardResult.handled());
+        }
     }
 }

--- a/velocity/src/main/java/com/vexsoftware/votifier/velocity/VelocityBackendServer.java
+++ b/velocity/src/main/java/com/vexsoftware/votifier/velocity/VelocityBackendServer.java
@@ -1,42 +1,30 @@
 package com.vexsoftware.votifier.velocity;
 
 import com.velocitypowered.api.proxy.ProxyServer;
-import com.velocitypowered.api.proxy.ServerConnection;
-import com.velocitypowered.api.proxy.server.ServerInfo;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.vexsoftware.votifier.platform.BackendServer;
-
-import java.util.Optional;
 
 class VelocityBackendServer implements BackendServer {
     private final ProxyServer server;
-    private final ServerInfo info;
+    private final RegisteredServer rs;
 
-    VelocityBackendServer(ProxyServer server, ServerInfo info) {
+    VelocityBackendServer(ProxyServer server, RegisteredServer rs) {
         this.server = server;
-        this.info = info;
+        this.rs = rs;
     }
 
     @Override
     public String getName() {
-        return info.getName();
+        return rs.getServerInfo().getName();
     }
 
     @Override
     public boolean sendPluginMessage(String channel, byte[] data) {
-        Optional<ServerConnection> connection = server.getAllPlayers().stream()
-                .map(p -> p.getCurrentServer().filter(s -> s.getServerInfo().equals(info)))
-                .filter(Optional::isPresent)
-                .findAny()
-                .flatMap(o -> o);
-        if (connection.isPresent()) {
-            connection.get().sendPluginMessage(VelocityUtil.getId(channel), data);
-            return true;
-        }
-        return false;
+        return rs.sendPluginMessage(VelocityUtil.getId(channel), data);
     }
 
     @Override
     public String toString() {
-        return info.getName();
+        return rs.getServerInfo().getName();
     }
 }

--- a/velocity/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlugin.java
+++ b/velocity/src/main/java/com/vexsoftware/votifier/velocity/VotifierPlugin.java
@@ -238,8 +238,7 @@ public class VotifierPlugin implements VoteHandler, ProxyVotifierPlugin {
             // Initialize the configuration file.
             String cfgStr = new String(ByteStreams.toByteArray(VotifierPlugin.class.getResourceAsStream("/config.toml")), StandardCharsets.UTF_8);
             String token = TokenUtil.newToken();
-            // TODO: Velocity doesn't expose any bind address, so use a temporary workaround
-            cfgStr = cfgStr.replace("%ip%", "0.0.0.0");
+            cfgStr = cfgStr.replace("%ip%", server.getBoundAddress().getAddress().getHostAddress());
             cfgStr = cfgStr.replace("%default_token%", token);
 
             /*
@@ -365,6 +364,6 @@ public class VotifierPlugin implements VoteHandler, ProxyVotifierPlugin {
 
     @Override
     public Optional<BackendServer> getServer(String name) {
-        return server.getServerInfo(name).map(s -> new VelocityBackendServer(server, s));
+        return server.getServer(name).map(s -> new VelocityBackendServer(server, s));
     }
 }


### PR DESCRIPTION
Build 251+ of Velocity includes breaking changes, including changes that affect NuVotifier. Notably, Velocity now supports a generic method of sending plugin messages to remote servers (it will pick a client), the plugin messaging API was redone, and the proxy's bound address is now exposed.