### PR TITLE
Use 'new File(parent, name)' instead of 'new File(parent + "/"+name)'

### DIFF
--- a/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
+++ b/bungeecord/src/main/java/com/vexsoftware/votifier/bungee/NuVotifier.java
@@ -88,8 +88,8 @@ public class NuVotifier extends Plugin implements VoteHandler, ProxyVotifierPlug
         }
 
         // Handle configuration.
-        File config = new File(getDataFolder() + "/config.yml");
-        File rsaDirectory = new File(getDataFolder() + "/rsa");
+        File config = new File(getDataFolder() , "config.yml");
+        File rsaDirectory = new File(getDataFolder() , "rsa");
         Configuration configuration;
 
         if (!config.exists()) {

--- a/common/src/main/java/com/vexsoftware/votifier/net/protocol/v1crypto/RSAIO.java
+++ b/common/src/main/java/com/vexsoftware/votifier/net/protocol/v1crypto/RSAIO.java
@@ -69,12 +69,12 @@ public class RSAIO {
      */
     public static KeyPair load(File directory) throws Exception {
         // Read the public key file.
-        File publicKeyFile = new File(directory + "/public.key");
+        File publicKeyFile = new File(directory, "public.key");
         byte[] encodedPublicKey = Files.readAllBytes(publicKeyFile.toPath());
         encodedPublicKey = Base64.getDecoder().decode(new String(encodedPublicKey, StandardCharsets.UTF_8));
 
         // Read the private key file.
-        File privateKeyFile = new File(directory + "/private.key");
+        File privateKeyFile = new File(directory, "private.key");
         byte[] encodedPrivateKey = Files.readAllBytes(privateKeyFile.toPath());
         encodedPrivateKey = Base64.getDecoder().decode(new String(encodedPrivateKey, StandardCharsets.UTF_8));
 


### PR DESCRIPTION
Just like my last pull request ( #110 ) but now directly with the 2 argument constructor and in 2 other files.
With this change the plugin will be able to run properly on Windows computers.